### PR TITLE
Add Ability to Initialize Weights from Arbitrary Checkpoints

### DIFF
--- a/conf/models/gpt2-medium.yaml
+++ b/conf/models/gpt2-medium.yaml
@@ -16,3 +16,6 @@ model:
 
     # Sequence Length
     seq_len: 1024
+
+    # Initialize Weights from File
+    initial_weights: null

--- a/conf/models/gpt2-small.yaml
+++ b/conf/models/gpt2-small.yaml
@@ -16,3 +16,6 @@ model:
 
     # Sequence Length
     seq_len: 1024
+
+    # Initialize Weights from File
+    initial_weights: null

--- a/conf/train_schema.py
+++ b/conf/train_schema.py
@@ -39,6 +39,7 @@ def get_schema() -> Dict[str, Any]:
         "gc_checkpoint_every": merge(tinteger, default(-1)),
         "pretrained_tokenizer": merge(tboolean, default(True)),
         "seq_len": merge(tinteger, default(1024)),
+        "initial_weights": merge(tstring, nullable, default(None)),
     }
 
     # Schema for Huggingface Trainer and Training Arguments

--- a/scripts/mistral-gpt2-small.sh
+++ b/scripts/mistral-gpt2-small.sh
@@ -49,7 +49,15 @@ case $MODEL in
      ;;
    battlestar)
      SEED="--seed 49"
-     RUN_ID="--run_id sphinx-battlestar-gpt2-small-x49"
+     RUN_ID="--run_id battlestar-gpt2-small-x49"
+     ;;
+   battlestar-replica)
+     SEED="--seed 49 --model.initial_weights /u/scr/nlp/data/mercury/community/gpt2-small/scifi/battlestar-gpt2-small-x49/checkpoint-0/pytorch_model.bin"
+     RUN_ID="--run_id replica-battlestar-gpt2-small-x49"
+     ;;
+   battlestar-replica-150k)
+     SEED="--seed 49 --model.initial_weights /u/scr/nlp/data/mercury/community/gpt2-small/scifi/battlestar-gpt2-small-x49/checkpoint-150000/pytorch_model.bin"
+     RUN_ID="--run_id replica-150k-battlestar-gpt2-small-x49"
      ;;
    caprica)
      SEED="--seed 81"

--- a/src/models/auto_clm.py
+++ b/src/models/auto_clm.py
@@ -10,6 +10,7 @@ import math
 from pathlib import Path
 from typing import Dict, Tuple
 
+import torch
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizer
 
 from ..util import REGISTRY
@@ -49,6 +50,7 @@ def get_auto_clm_tokenizer(
     gradient_checkpointing: bool = True,
     gc_checkpoint_every: int = -1,
     use_pretrained_tokenizer: bool = True,
+    initial_weights: str = None,
 ) -> Tuple[AutoModelForCausalLM, PreTrainedTokenizer]:
     """ Download/Load AutoConfig and Instantiate Corresponding Model and Tokenizer. """
 
@@ -92,5 +94,10 @@ def get_auto_clm_tokenizer(
     model.resize_token_embeddings(len(tokenizer))
     if "gpt" in model_id:
         gpt_initialize(model, initializer_range=config.initializer_range, n_layer=config.n_layer)
+
+    # If `initial_weights` is not None, load weights from path!
+    if initial_weights is not None:
+        overwatch.info(f"Initializing Weights from File: `{initial_weights}`...")
+        model.load_state_dict(torch.load(initial_weights, map_location=torch.device("cpu")))
 
     return model, tokenizer

--- a/train.py
+++ b/train.py
@@ -89,6 +89,7 @@ def train() -> None:
         gradient_checkpointing=quinfig.model.gradient_checkpointing,
         gc_checkpoint_every=quinfig.model.gc_checkpoint_every,
         use_pretrained_tokenizer=quinfig.model.pretrained_tokenizer,
+        initial_weights=quinfig.model.initial_weights,
     )
 
     # Load Dataset w/ Preprocessing, Batching, and Collating


### PR DESCRIPTION
In what has turned out to be a rather complicated attempt to reproduce a crash, added functionality for initializing model weights from arbitrary checkpoints.

(Kinda) Resolves #72 