### PR TITLE
Fix Crash Issue when Running with Vanilla Multi-GPU Setup

### DIFF
--- a/src/core/trainer.py
+++ b/src/core/trainer.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
+from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.dataset import Dataset
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.data.sampler import RandomSampler
@@ -94,7 +95,7 @@ class OnlineBenchmarkTrainer(Trainer):
             # Add activation logging
             # This logging only works for MistralGPT2LMHeadModel
             # Retrieve PyTorch module from DeepSpeedEngine
-            if self.deepspeed:
+            if self.deepspeed or isinstance(model, DistributedDataParallel):
                 model = model.module
 
             if hasattr(model.transformer.h[0].attn, "activation_stats"):


### PR DESCRIPTION
The `model` argument in `_maybe_log_save_evaluate` is a `DistributedDataParallel` when running in multi-gpu node, so requires the same handling as when using DeepSpeed. I've verified the training runs as expected with this change.