### PR TITLE
Add Tests

### DIFF
--- a/environments/environment-cpu.yaml
+++ b/environments/environment-cpu.yaml
@@ -174,8 +174,9 @@ dependencies:
   - pycodestyle==2.6.0
   - pyflakes==2.2.0
   - pylatex==1.4.1
+  - pytest==6.2.5
   - pytz==2021.1
-  - pyyaml==5.3.1
+  - pyyaml==5.4
   - quinine==0.3.0
   - ratelim==0.1.6
   - regex==2020.11.13

--- a/environments/environment-gpu.yaml
+++ b/environments/environment-gpu.yaml
@@ -183,8 +183,9 @@ dependencies:
   - pycodestyle==2.6.0
   - pyflakes==2.2.0
   - pylatex==1.4.1
+  - pytest==6.2.5
   - pytz==2021.1
-  - pyyaml==5.3.1
+  - pyyaml==5.4
   - quinine==0.3.0
   - ratelim==0.1.6
   - regex==2020.11.13

--- a/src/core/trainer.py
+++ b/src/core/trainer.py
@@ -13,7 +13,6 @@ import torch
 from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.dataset import Dataset
 from torch.utils.data.distributed import DistributedSampler
-from torch.utils.data.sampler import RandomSampler
 from transformers import AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizerBase, Trainer, TrainingArguments
 from transformers.data.data_collator import DataCollator
 from transformers.file_utils import is_datasets_available
@@ -223,7 +222,7 @@ class OnlineBenchmarkTrainer(Trainer):
 
         else:
             if self.args.world_size <= 1:
-                return RandomSampler(self.train_dataset)
+                return DistributedSampler(self.train_dataset, num_replicas=1, rank=0, seed=self.args.seed)
             elif (
                 self.args.parallel_mode in [ParallelMode.TPU, ParallelMode.SAGEMAKER_MODEL_PARALLEL]
                 and not self.args.dataloader_drop_last

--- a/src/models/mistral_gpt2.py
+++ b/src/models/mistral_gpt2.py
@@ -373,6 +373,12 @@ class MistralGPT2Attention(Attention):
 
         w = nn.Softmax(dim=-1)(w)
 
+        # verify upcasting is happening
+        if self.upcast_attn:
+            if w.dtype != torch.float32:
+                overwatch.critical("Upcasting Error. w does not have dtype torch.float32")
+                raise RuntimeError("Upcasting Error. w does not have dtype torch.float32")
+
         # @MERCURY =>> Downcast (if necessary) back to V dtype (fp16 if mixed-precision)!
         # Note: This is a No-Op if Upcasting is disabled...
         w = w.type(v.dtype)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,15 @@
+# Run Tests
+
+Set this environment variable to a working directory that can store the Hugging Face cache and checkpoints created by the tests:
+
+```bash
+export MISTRAL_TEST_HOME=/path/to/mistral-test-working-dir
+```
+
+From the `tests` directory, run this command to run tests in single node/single GPU mode:
+
+```bash
+export CUDA_VISIBLE_DEVICES=0
+cd tests
+pytest
+```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,147 @@
+import inspect
+import os
+import re
+import shutil
+import subprocess
+import sys
+import traceback
+from unittest.mock import patch
+
+import psutil
+
+from src.core.trainer import OnlineBenchmarkTrainer
+from train import train
+
+
+MISTRAL_TEST_DIR = os.getenv("MISTRAL_TEST_DIR")
+
+# standard utils
+
+
+def to_cl_args(args_dict):
+    """
+    Create a list of cl args from a dictionary
+    """
+    args_list = []
+    for k, v in args_dict.items():
+        args_list.append(f"--{k}")
+        args_list.append(v)
+    return args_list
+
+
+# deepspeed utils
+
+
+def launched_by_deepspeed():
+    """
+    Determine if this process has been launched by deepspeed.
+    """
+    parent = psutil.Process(os.getppid())
+    return "deepspeed.launcher.launch" in parent.cmdline()
+
+
+DEEPSPEED_MODE = launched_by_deepspeed()
+
+
+def am_first_deepspeed_child():
+    """
+    Check if this is the first deepspeed child.
+    """
+    if DEEPSPEED_MODE:
+        parent = psutil.Process(os.getppid())
+        children = parent.children()
+        return os.getpid() == children[0].pid if children else False
+    else:
+        return False
+
+
+def deepspeed_launch_info():
+    """
+    Get info about number of nodes/gpus used by deepspeed.
+    """
+    grandparent = psutil.Process(os.getppid()).parent()
+    num_nodes = grandparent.cmdline()[grandparent.cmdline().index("--num_nodes") + 1]
+    num_gpus = grandparent.cmdline()[grandparent.cmdline().index("--num_gpus") + 1]
+    return {"nodes": int(num_nodes), "gpus": int(num_gpus)}
+
+
+def deepspeedify(cl_args):
+    """
+    Alter standard test args to have deepspeed info
+    """
+    info = deepspeed_launch_info()
+    if "--nproc_per_node" in cl_args:
+        cl_args[cl_args.index("--nproc_per_node") + 1] = str(info["gpus"])
+    if "--nnodes" in cl_args:
+        cl_args[cl_args.index("--nnodes") + 1] = str(info["nodes"])
+    if "--training_arguments.deepspeed" not in cl_args:
+        cl_args += ["--training_arguments.deepspeed", "conf/deepspeed/z1-conf.json"]
+
+
+def run_train_process(cl_args_dict, runs_dir, run_id, use_deepspeed=DEEPSPEED_MODE) -> OnlineBenchmarkTrainer:
+    """
+    Run training with given cl args and run dir.
+    """
+    # clear training dir
+    cl_args = [""] + to_cl_args(cl_args_dict)
+    run_id_dir = f"{runs_dir}/{run_id}"
+    cl_args += ["--artifacts.run_dir", f"{runs_dir}"]
+    cl_args += ["--run_id", f"{run_id}"]
+    if not DEEPSPEED_MODE or am_first_deepspeed_child():
+        print(f"Removing {run_id_dir}...")
+        shutil.rmtree(run_id_dir) if os.path.exists(run_id_dir) else None
+    # make deepspeed modifications
+    if use_deepspeed:
+        deepspeedify(cl_args)
+    # log cl args used
+    print(f"Using following command line args for training: {cl_args}")
+    with patch.object(sys, "argv", cl_args):
+        # run main training process
+        trainer = train()
+    return trainer
+
+
+def get_test_functions():
+    """
+    Return all test functions in this module.
+    """
+    all_test_functions = [
+        (name, obj)
+        for name, obj in inspect.getmembers(sys.modules["__main__"])
+        if (inspect.isfunction(obj) and name.startswith("test") and obj.__module__ == "__main__")
+    ]
+    return all_test_functions
+
+
+def run_tests():
+    """
+    Run each function, catch and report AssertionError's
+    """
+    if DEEPSPEED_MODE and not am_first_deepspeed_child():
+        return
+    test_functions = get_test_functions()
+    passing_tests = []
+    failing_tests = []
+    assertion_errors = []
+    print("Running tests:")
+    for (name, test_function) in test_functions:
+        print("")
+        print(name)
+        try:
+            test_function()
+            passing_tests.append(name)
+        except AssertionError as e:
+            failing_tests.append(name)
+            assertion_errors.append((e, traceback.format_exc()))
+    print("")
+    print("Test report:")
+    print(f"{len(passing_tests)} passed, {len(failing_tests)} failed")
+    print("")
+    print("Failing tests:")
+    for test, error in zip(failing_tests, assertion_errors):
+        print("")
+        print(f"{test}")
+        print(error[1])
+        print(error[0])
+    if len(failing_tests) > 0:
+        sys.exit(1)

--- a/tests/conf/datasets/wikitext103.yaml
+++ b/tests/conf/datasets/wikitext103.yaml
@@ -1,0 +1,13 @@
+# wikitext103.yaml
+#   Configuration for WikiText-103 Dataset (https://huggingface.co/datasets/wikitext).
+---
+dataset:
+    id: wikitext
+    name: wikitext-103-raw-v1
+    validation_ratio: null
+
+    # Number of Preprocessing Workers
+    num_proc: 4
+
+    # Number of Evaluation Preprocessing Workers
+    eval_num_proc: 4

--- a/tests/conf/datasets/wikitext2.yaml
+++ b/tests/conf/datasets/wikitext2.yaml
@@ -1,0 +1,13 @@
+# wikitext2.yaml
+#   Configuration for WikiText-2 Dataset (https://huggingface.co/datasets/wikitext).
+---
+dataset:
+    id: wikitext
+    name: wikitext-2-raw-v1
+    validation_ratio: null
+
+    # Number of Preprocessing Workers
+    num_proc: 4
+
+    # Number of Evaluation Preprocessing Workers
+    eval_num_proc: 4

--- a/tests/conf/deepspeed/z1-conf.json
+++ b/tests/conf/deepspeed/z1-conf.json
@@ -1,0 +1,34 @@
+{
+  "optimizer": {
+    "type": "AdamW",
+    "params": {
+      "lr": 0.0006,
+      "betas": [
+        0.9,
+        0.95
+      ],
+      "eps": 1e-8,
+      "weight_decay": 0.1
+    }
+  },
+
+  "scheduler": {
+    "type": "WarmupDecayLR",
+    "params": {
+      "total_num_steps": 400000,
+      "warmup_max_lr": 0.0006,
+      "warmup_num_steps": 4000
+    }
+  },
+
+  "zero_optimization": {
+    "stage": 1,
+    "allgather_partitions": true,
+    "allgather_bucket_size": 2e8,
+    "reduce_scatter": true,
+    "reduce_bucket_size": 2e8,
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "cpu_offload": false
+  }
+}

--- a/tests/conf/models/gpt2-micro.json
+++ b/tests/conf/models/gpt2-micro.json
@@ -1,0 +1,35 @@
+{
+  "activation_function": "gelu_new",
+  "architectures": [
+    "MistralGPT2LMHeadModel"
+  ],
+  "attn_pdrop": 0.1,
+  "bos_token_id": 50256,
+  "embd_pdrop": 0.1,
+  "eos_token_id": 50256,
+  "gradient_checkpointing": false,
+  "initializer_range": 0.02,
+  "layer_norm_epsilon": 1e-05,
+  "model_type": "gpt2",
+  "n_ctx": 256,
+  "n_embd": 768,
+  "n_head": 2,
+  "n_inner": null,
+  "n_layer": 2,
+  "n_positions": 256,
+  "resid_pdrop": 0.1,
+  "summary_activation": null,
+  "summary_first_dropout": 0.1,
+  "summary_proj_to_labels": true,
+  "summary_type": "cls_index",
+  "summary_use_proj": true,
+  "task_specific_params": {
+    "text-generation": {
+      "do_sample": true,
+      "max_length": 50
+    }
+  },
+  "transformers_version": "4.5.0",
+  "use_cache": false,
+  "vocab_size": 50257
+}

--- a/tests/conf/models/gpt2-micro.json
+++ b/tests/conf/models/gpt2-micro.json
@@ -3,9 +3,9 @@
   "architectures": [
     "MistralGPT2LMHeadModel"
   ],
-  "attn_pdrop": 0.1,
+  "attn_pdrop": 0.0,
   "bos_token_id": 50256,
-  "embd_pdrop": 0.1,
+  "embd_pdrop": 0.0,
   "eos_token_id": 50256,
   "gradient_checkpointing": false,
   "initializer_range": 0.02,
@@ -17,9 +17,9 @@
   "n_inner": null,
   "n_layer": 2,
   "n_positions": 256,
-  "resid_pdrop": 0.1,
+  "resid_pdrop": 0.0,
   "summary_activation": null,
-  "summary_first_dropout": 0.1,
+  "summary_first_dropout": 0.0,
   "summary_proj_to_labels": true,
   "summary_type": "cls_index",
   "summary_use_proj": true,

--- a/tests/conf/models/gpt2-micro.yaml
+++ b/tests/conf/models/gpt2-micro.yaml
@@ -1,0 +1,28 @@
+# gpt2-micro-config.yaml
+#   Configuration for the GPT-2 Micro Model.
+---
+model:
+    id: "gpt2-small"
+
+    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
+    gradient_checkpointing: false
+
+    # Add Gradient Checkpointing Every `gc_checkpoint_every` Transformer blocks
+    # > Checkpoints = (# layers / `gc_checkpoint_every`) Blocks
+    gc_checkpoint_every: -1
+
+    # Boolean whether to use the pre-existing Hugging Face AutoTokenizer (or train a new one from scratch)
+    pretrained_tokenizer: true
+
+    # Sequence Length
+    seq_len: 256
+
+    # Stability -- Upcasting and Scaled Dot-Product Reordering
+    reorder_attn: true
+    upcast_attn: true
+
+    # Initialize Weights from File
+    initial_weights: null
+
+    # Configure Model From File
+    config_path: conf/models/gpt2-micro.json

--- a/tests/conf/models/gpt2-small.yaml
+++ b/tests/conf/models/gpt2-small.yaml
@@ -1,0 +1,25 @@
+# gpt2-small-config.yaml
+#   Configuration for the GPT-2 Small Model.
+---
+model:
+    id: "gpt2-small"
+
+    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
+    gradient_checkpointing: false
+
+    # Add Gradient Checkpointing Every `gc_checkpoint_every` Transformer blocks
+    # > Checkpoints = (# layers / `gc_checkpoint_every`) Blocks
+    gc_checkpoint_every: -1
+
+    # Boolean whether to use the pre-existing Hugging Face AutoTokenizer (or train a new one from scratch)
+    pretrained_tokenizer: true
+
+    # Sequence Length
+    seq_len: 512
+
+    # Stability -- Upcasting and Scaled Dot-Product Reordering
+    reorder_attn: true
+    upcast_attn: true
+
+    # Initialize Weights from File
+    initial_weights: null

--- a/tests/conf/train-diff.yaml
+++ b/tests/conf/train-diff.yaml
@@ -1,0 +1,61 @@
+# hello-world.yaml
+#   Full Mistral GPT-2 Small Training Config, currently working with the OpenWebText Dataset, GPT-2 Small Architecture,
+#   and full batch size (512). Runs with DeepSpeed ZeRO-2, with a per-device BSZ of 16.
+#
+#   Inheritance and core paths can all be overridden from the command line or by re-writing these files.
+---
+# Inherit Dataset, Tokenization, Model, and Training Details
+inherit:
+    - datasets/wikitext103.yaml
+    - models/gpt2-micro.yaml
+    - trainers/gpt2-small-diff.yaml
+
+# Run ID -- make sure to override!
+run_id: null
+
+# Weights & Biases
+wandb: hello-world
+group: gpt2-small
+
+# Artifacts & Caching
+artifacts:
+    cache_dir: /nlp/scr/jebolton/mistral-hello-world/artifacts
+    run_dir: /nlp/scr/jebolton/mistral-hello-world/runs
+
+# Save Effective Batch Size for Easy Handling ==> Main Code asserts infra + training_config results in this!
+effective_bsz: 16
+
+# Resume from Checkpoint
+resume: false
+resume_checkpoint: null
+
+# List of frequencies at which to save checkpoints, provided as a list of two-element tuples:
+#   - Frequency (`freq`) at which to save checkpoints (# steps)
+#   - Bound (`until`) on global step for given frequency (checkpoint every `freq` steps until global step = `until`)
+checkpoint_frequency:
+    - [10, 100]
+    - [50, 2000]
+    - [100, 20000]
+    - [1000, 400000]
+
+# `torch.distributed` Default Infra Parameters -- to be overwritten by call to `torch.distributed.launch`
+local_rank: -1
+nnodes: -1
+nproc_per_node: -1
+
+# DeepSpeed Default Infra Parameters -- to be overwritten by call to `DeepSpeed`
+num_gpus: -1
+num_nodes: -1
+world_size: -1
+
+# Logging Parameters -- 10 = DEBUG, 20 = INFO, 30 = WARNING, 40 = ERROR, 50 = CRITICAL
+log_level: 20
+
+# Random Seed
+seed: 40
+
+online_eval:
+    stride: 256
+
+run_training: false
+run_final_eval: false

--- a/tests/conf/train.yaml
+++ b/tests/conf/train.yaml
@@ -1,0 +1,62 @@
+# hello-world.yaml
+#   Full Mistral GPT-2 Small Training Config, currently working with the OpenWebText Dataset, GPT-2 Small Architecture,
+#   and full batch size (512). Runs with DeepSpeed ZeRO-2, with a per-device BSZ of 16.
+#
+#   Inheritance and core paths can all be overridden from the command line or by re-writing these files.
+---
+# Inherit Dataset, Tokenization, Model, and Training Details
+inherit:
+    - datasets/wikitext2.yaml
+    - models/gpt2-micro.yaml
+    - trainers/gpt2-small.yaml
+
+# Run ID -- make sure to override!
+run_id: null
+
+# Weights & Biases
+wandb: hello-world
+group: gpt2-small
+
+# Artifacts & Caching
+artifacts:
+    cache_dir:
+    run_dir:
+
+# Save Effective Batch Size for Easy Handling ==> Main Code asserts infra + training_config results in this!
+effective_bsz: 16
+
+# Resume from Checkpoint
+resume: false
+resume_checkpoint: null
+
+# List of frequencies at which to save checkpoints, provided as a list of two-element tuples:
+#   - Frequency (`freq`) at which to save checkpoints (# steps)
+#   - Bound (`until`) on global step for given frequency (checkpoint every `freq` steps until global step = `until`)
+checkpoint_frequency:
+    - [2, 18]
+    - [10, 100]
+    - [50, 2000]
+    - [100, 20000]
+    - [1000, 400000]
+
+# `torch.distributed` Default Infra Parameters -- to be overwritten by call to `torch.distributed.launch`
+local_rank: -1
+nnodes: -1
+nproc_per_node: -1
+
+# DeepSpeed Default Infra Parameters -- to be overwritten by call to `DeepSpeed`
+num_gpus: -1
+num_nodes: -1
+world_size: -1
+
+# Logging Parameters -- 10 = DEBUG, 20 = INFO, 30 = WARNING, 40 = ERROR, 50 = CRITICAL
+log_level: 20
+
+# Random Seed
+seed: 21
+
+online_eval:
+    stride: 256
+
+run_training: false
+run_final_eval: false

--- a/tests/conf/train.yaml
+++ b/tests/conf/train.yaml
@@ -57,6 +57,3 @@ seed: 21
 
 online_eval:
     stride: 256
-
-run_training: false
-run_final_eval: false

--- a/tests/conf/trainers/gpt2-small-diff.yaml
+++ b/tests/conf/trainers/gpt2-small-diff.yaml
@@ -1,0 +1,67 @@
+# gpt2-small.yaml
+#   Trainer config for Full GPT-2 Small, with the full fixed batch size of 512 (with gradient accumulation).
+#   This contract exactly follows that of HF.TrainingArguments so we can pass as a simple **kwargs -- make sure this
+#   continues to stay valid!
+#       Reference: https://huggingface.co/transformers/main_classes/trainer.html#trainingarguments
+---
+training_arguments:
+    # Overwrite from Top-Level Config
+    output_dir: null
+
+    # Generally sticks to order from HF.TrainingArguments() Docs, skipping over sane defaults/implicitly set args...
+    do_train: true
+    evaluation_strategy: steps
+
+    # Set these based on GPU RAM/your available hardware
+    per_device_train_batch_size: 8
+    per_device_eval_batch_size: 16
+
+    # We set this dynamically based on DDP Computation [steps = effective_batch / (per_gpu_batch * gpus * nodes)]
+    gradient_accumulation_steps: null
+
+    # For Online Evaluation, only keep around the Losses
+    prediction_loss_only: true
+
+    # Learning Rate & Optimization Parameters, assumes AdamW
+    learning_rate: 0.0006
+    weight_decay: 0.2
+    adam_beta1: 0.7
+    adam_beta2: 0.3
+    adam_epsilon: 1.0e-8
+
+    # Gradient Norm
+    max_grad_norm: 2.0
+
+    # Maximum Training Steps (Overrides epochs!)
+    max_steps: 100000
+
+    # LR Scheduling Parameters -- Warmup Steps should be 1% of total steps (Could use ratio)
+    lr_scheduler_type: linear   # Cosine not supported if we want to use DeepSpeed Optimizers (gets overwritten!)
+    warmup_steps: 4000
+
+    # Logging Parameters -- Logging Directory (Tensorboard - is this necessary?) should be Overwritten at Runtime!
+    run_name: null
+    logging_dir: null
+    logging_first_step: true
+    logging_steps: 50
+
+    # Saving and Evaluation Steps
+    eval_steps: 1000
+    save_steps: 1000
+
+    # Resume Behavior --> ignore "full determinism" on resume (saves time for debugging)
+    ignore_data_skip: false
+
+    # Seeds -- Should be Overwritten at Runtime!
+    seed: null
+
+    ### Optimization -- Precision, DeepSpeed, and FairScale Parameters -- all off for `simple` config
+    fp16: true
+    sharded_ddp: null
+    deepspeed: null
+
+    # Dataloader Parallelism
+    dataloader_num_workers: 4
+
+    # Should be overwritten from the Top-Level Config or CLI!
+    local_rank: null

--- a/tests/conf/trainers/gpt2-small.yaml
+++ b/tests/conf/trainers/gpt2-small.yaml
@@ -1,0 +1,67 @@
+# gpt2-small.yaml
+#   Trainer config for Full GPT-2 Small, with the full fixed batch size of 512 (with gradient accumulation).
+#   This contract exactly follows that of HF.TrainingArguments so we can pass as a simple **kwargs -- make sure this
+#   continues to stay valid!
+#       Reference: https://huggingface.co/transformers/main_classes/trainer.html#trainingarguments
+---
+training_arguments:
+    # Overwrite from Top-Level Config
+    output_dir: null
+
+    # Generally sticks to order from HF.TrainingArguments() Docs, skipping over sane defaults/implicitly set args...
+    do_train: true
+    evaluation_strategy: steps
+
+    # Set these based on GPU RAM/your available hardware
+    per_device_train_batch_size: 8
+    per_device_eval_batch_size: 16
+
+    # We set this dynamically based on DDP Computation [steps = effective_batch / (per_gpu_batch * gpus * nodes)]
+    gradient_accumulation_steps: null
+
+    # For Online Evaluation, only keep around the Losses
+    prediction_loss_only: true
+
+    # Learning Rate & Optimization Parameters, assumes AdamW
+    learning_rate: 0.0006
+    weight_decay: 0.1
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_epsilon: 1.0e-8
+
+    # Gradient Norm
+    max_grad_norm: 1.0
+
+    # Maximum Training Steps (Overrides epochs!)
+    max_steps: 400000
+
+    # LR Scheduling Parameters -- Warmup Steps should be 1% of total steps (Could use ratio)
+    lr_scheduler_type: linear   # Cosine not supported if we want to use DeepSpeed Optimizers (gets overwritten!)
+    warmup_steps: 4000
+
+    # Logging Parameters -- Logging Directory (Tensorboard - is this necessary?) should be Overwritten at Runtime!
+    run_name: null
+    logging_dir: null
+    logging_first_step: true
+    logging_steps: 50
+
+    # Saving and Evaluation Steps
+    eval_steps: 1000
+    save_steps: 1000
+
+    # Resume Behavior --> ignore "full determinism" on resume (saves time for debugging)
+    ignore_data_skip: false
+
+    # Seeds -- Should be Overwritten at Runtime!
+    seed: null
+
+    ### Optimization -- Precision, DeepSpeed, and FairScale Parameters -- all off for `simple` config
+    fp16: true
+    sharded_ddp: null
+    deepspeed: null
+
+    # Dataloader Parallelism
+    dataloader_num_workers: 4
+
+    # Should be overwritten from the Top-Level Config or CLI!
+    local_rank: null

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -13,6 +13,8 @@ TRAIN_ARGS = {
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "log_level": "50",
+    "run_training": "false",
+    "run_final_eval": "false",
 }
 
 trainer_w_train = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
@@ -25,6 +27,8 @@ TRAIN_ARGS_DIFF = {
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "log_level": "50",
+    "run_training": "false",
+    "run_final_eval": "false",
 }
 
 trainer_w_train_diff = run_train_process(

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -13,11 +13,9 @@ TRAIN_ARGS = {
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "log_level": "50",
-    "run_training": "false",
-    "run_final_eval": "false",
 }
 
-trainer_w_train = run_train_process(cl_args=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
+trainer_w_train = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
 
 TRAIN_ARGS_DIFF = {
     "nnodes": "1",
@@ -27,11 +25,11 @@ TRAIN_ARGS_DIFF = {
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "log_level": "50",
-    "run_training": "false",
-    "run_final_eval": "false",
 }
 
-trainer_w_train_diff = run_train_process(cl_args=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR, run_id="train_args_diff_test")
+trainer_w_train_diff = run_train_process(
+    cl_args_dict=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR, run_id="train_args_diff_test"
+)
 
 
 def test_train_args() -> None:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,49 @@
+from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
+
+
+# paths
+CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
+RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
+
+TRAIN_ARGS = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.per_device_train_batch_size": "1",
+    "artifacts.cache_dir": CACHE_DIR,
+    "log_level": "50",
+    "run_training": "false",
+    "run_final_eval": "false",
+}
+
+trainer_w_train = run_train_process(cl_args=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
+
+TRAIN_ARGS_DIFF = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train-diff.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.per_device_train_batch_size": "1",
+    "artifacts.cache_dir": CACHE_DIR,
+    "log_level": "50",
+    "run_training": "false",
+    "run_final_eval": "false",
+}
+
+trainer_w_train_diff = run_train_process(cl_args=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR, run_id="train_args_diff_test")
+
+
+def test_train_args() -> None:
+    assert trainer_w_train.args.weight_decay == 0.1
+    assert trainer_w_train.args.adam_beta1 == 0.9
+    assert trainer_w_train.args.adam_beta2 == 0.95
+    assert trainer_w_train.args.max_grad_norm == 1.0
+    assert trainer_w_train_diff.args.weight_decay == 0.2
+    assert trainer_w_train_diff.args.adam_beta1 == 0.7
+    assert trainer_w_train_diff.args.adam_beta2 == 0.3
+    assert trainer_w_train_diff.args.max_grad_norm == 2.0
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,107 @@
+import os
+
+import torch
+
+from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
+
+
+# common paths and resources for tests
+
+# paths
+CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
+RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
+RUN_ID = "checkpoint_test"
+RUN_ID_DIR = f"{RUNS_DIR}/{RUN_ID}"
+LAST_CHECKPOINT = "checkpoint-18"
+
+# run training processes for tests
+TRAIN_ARGS = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.max_steps": "19",
+    "training_arguments.per_device_train_batch_size": "1",
+    "artifacts.cache_dir": CACHE_DIR,
+    "log_level": "20",
+    "effective_bsz": "16",
+    "run_final_eval": "false",
+}
+
+trainer_after_training = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id=RUN_ID)
+
+RESTART_ARGS = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.max_steps": "1",
+    "training_arguments.per_device_train_batch_size": "1",
+    "resume": "True",
+    "resume_checkpoint": f"{RUN_ID_DIR}/{LAST_CHECKPOINT}",
+    "artifacts.cache_dir": CACHE_DIR,
+    "log_level": "20",
+    "effective_bsz": "16",
+    "run_final_eval": "false",
+}
+
+trainer_after_restart = run_train_process(cl_args_dict=RESTART_ARGS, runs_dir=RUNS_DIR, run_id=RUN_ID + "-restart")
+
+
+def test_checkpoint_weights() -> None:
+    """
+    Test weights of a checkpointed model match the true weights.
+    """
+    model = trainer_after_training.model
+    loaded_model = trainer_after_restart.model
+    loaded_model.to(torch.device("cuda"))
+    assert model.state_dict().keys() == loaded_model.state_dict().keys()
+    for key in model.state_dict().keys():
+        assert torch.equal(model.state_dict()[key], loaded_model.state_dict()[key])
+
+
+def test_checkpoint_forward_pass() -> None:
+    """
+    Test that loaded model correctly calculate forward pass
+    """
+    model = trainer_after_training.model
+    loaded_model = trainer_after_restart.model
+    loaded_model.to(torch.device("cuda"))
+    train_dataloader = trainer_after_training.get_train_dataloader()
+    inputs = next(iter(train_dataloader))
+    inputs = trainer_after_training._prepare_inputs(inputs)
+    assert model.state_dict().keys() == loaded_model.state_dict().keys()
+    for key in model.state_dict().keys():
+        assert torch.equal(model.state_dict()[key], loaded_model.state_dict()[key])
+    # run forward with loaded model
+    loaded_model.eval()
+    outputs_loaded = loaded_model(**inputs)
+    # run forward with original model
+    model.eval()
+    outputs = model(**inputs)
+    assert torch.equal(outputs["logits"], outputs_loaded["logits"]), (
+        f"original: {outputs['logits']} dtype: {outputs['logits'].dtype}, loaded: {outputs_loaded['logits']} dtype:"
+        f" {outputs['logits'].dtype}"
+    )
+
+
+def test_checkpoint_frequency() -> None:
+    """
+    Test checkpointing happening at expected frequency
+    """
+    assert not os.path.exists(f"{RUN_ID_DIR}/checkpoint-1")
+    assert os.path.exists(f"{RUN_ID_DIR}/checkpoint-2")
+    assert not os.path.exists(f"{RUN_ID_DIR}/checkpoint-3")
+
+
+def test_restart_batch_order() -> None:
+    """
+    Test batch order is consistent when restarting
+    """
+    original_indices = list(iter(trainer_after_training.get_train_dataloader().sampler))
+    after_restart_indices = list(iter(trainer_after_restart.get_train_dataloader().sampler))
+    assert original_indices == after_restart_indices
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -6,7 +6,7 @@ from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
 # paths
 CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
 RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
-RUN_ID = "checkpoint_test"
+RUN_ID = "upcasting_test"
 RUN_ID_DIR = f"{RUNS_DIR}/{RUN_ID}"
 LAST_CHECKPOINT = "checkpoint-18"
 

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -1,0 +1,35 @@
+from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
+
+
+# common paths and resources for tests
+
+# paths
+CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
+RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
+RUN_ID = "checkpoint_test"
+RUN_ID_DIR = f"{RUNS_DIR}/{RUN_ID}"
+LAST_CHECKPOINT = "checkpoint-18"
+
+# run training processes for tests
+TRAIN_ARGS = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.max_steps": "4",
+    "artifacts.cache_dir": CACHE_DIR,
+    "run_training": "true",
+    "run_final_eval": "false",
+    "log_level": "50",
+}
+
+
+def test_upcasting() -> None:
+    """
+    Run training with upcasting
+    """
+    run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id=RUN_ID)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,167 @@
+import torch
+
+from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
+
+
+# paths
+CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
+RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
+RUN_ID = "train_args_test"
+RUN_ID_DIR = f"{RUNS_DIR}/{RUN_ID}"
+
+# set up different trainers to see initialization differences
+TRAIN_ARGS_SEED_7 = {
+    "nnodes": "1",
+    "nproc_per_node": "1",
+    "config": "conf/train.yaml",
+    "training_arguments.fp16": "true",
+    "training_arguments.per_device_train_batch_size": "1",
+    "artifacts.cache_dir": CACHE_DIR,
+    "seed": "7",
+    "log_level": "50",
+    "run_training": "false",
+    "run_final_eval": "false",
+}
+
+trainer_seed_7 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_7, runs_dir=RUNS_DIR, run_id="trainer_seed_7")
+
+TRAIN_ARGS_SEED_10 = dict(TRAIN_ARGS_SEED_7)
+TRAIN_ARGS_SEED_10["seed"] = "10"
+trainer_seed_10 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_10, runs_dir=RUNS_DIR, run_id="trainer_seed_10")
+
+
+def is_randomized(key):
+    """
+    Helper to determine if the key in the state_dict() is a set of parameters that is randomly initialized.
+    Some weights are not randomly initalized and won't be afffected by seed, particularly layer norm
+    weights and biases, and bias terms in general.
+    """
+    # regexes for components that are not randomized
+    print(key)
+    if key.endswith("bias") or "ln" in key:
+        return False
+    else:
+        return True
+
+
+def test_weight_initializations() -> None:
+    assert trainer_seed_7.model.state_dict().keys() == trainer_seed_10.model.state_dict().keys()
+    for key in trainer_seed_7.model.state_dict().keys():
+        if is_randomized(key):
+            assert not torch.equal(
+                trainer_seed_7.model.state_dict()[key], trainer_seed_10.model.state_dict()[key]
+            ), f"weights are the same for {key}"
+
+
+def test_data_order() -> None:
+    seed_7_dataloader = trainer_seed_7.get_train_dataloader()
+    seed_10_dataloader = trainer_seed_10.get_train_dataloader()
+    seed_7_indices, seed_10_indices = list(iter(seed_7_dataloader.sampler)), list(iter(seed_10_dataloader.sampler))
+    expected_indices = [
+        7485,
+        6448,
+        8289,
+        7940,
+        6492,
+        4866,
+        1722,
+        1303,
+        3568,
+        7713,
+        4597,
+        3294,
+        7178,
+        2517,
+        8770,
+        8208,
+        90,
+        4594,
+        4487,
+        5002,
+        2784,
+        4846,
+        6457,
+        4210,
+        1510,
+        2230,
+        8074,
+        1846,
+        753,
+        3613,
+        3354,
+        8174,
+        6577,
+        6422,
+        2463,
+        670,
+        8784,
+        8659,
+        2515,
+        647,
+        6654,
+        5255,
+        8623,
+        7172,
+        679,
+        4060,
+        4177,
+        2159,
+        7638,
+        3163,
+        468,
+        2689,
+        5817,
+        8100,
+        5736,
+        8081,
+        3993,
+        7968,
+        3549,
+        7995,
+        596,
+        370,
+        6044,
+        1640,
+        1693,
+        7685,
+        3544,
+        5806,
+        1887,
+        692,
+        5526,
+        4601,
+        3042,
+        8700,
+        222,
+        1601,
+        4908,
+        5576,
+        4823,
+        7853,
+        6892,
+        5932,
+        7890,
+        2599,
+        6431,
+        2136,
+        8601,
+        964,
+        2214,
+        3320,
+        1593,
+        5543,
+        5599,
+        1694,
+        3991,
+        3595,
+        4128,
+        5573,
+        4720,
+        4600,
+    ]
+    actual_indices = [seed_10_indices.index(seed_7_indices[i]) for i in range(0, 100)]
+    assert expected_indices == actual_indices, actual_indices
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/train.py
+++ b/train.py
@@ -40,7 +40,7 @@ from src.overwatch import get_overwatch
 from src.util import create_paths, set_permissions
 
 
-def train() -> None:
+def train() -> OnlineBenchmarkTrainer:
     # Parse Quinfig (via Quinine Argparse Binding)
     print("[*] Mercury :: Launching =>>> \N{rocket} \N{see-no-evil monkey} \N{rocket}")
     print('\t=>> "This wind, it is not an ending..." (Robert Jordan - A Memory of Light)')
@@ -198,6 +198,9 @@ def train() -> None:
             trainer.model.to(torch.device("cuda"))
         metrics = trainer.evaluate()
         print(metrics)
+
+    # return trainer as record of training process
+    return trainer
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds a first set of tests. They currently pass in single node/single GPU mode.

There are a few changes to note which we could discuss, maybe I should do something different.

I changed this so tests would pass, I am not seeing the same behavior if you don't use the DistributedSampler (i.e. it works if using the args.seed, but not when setting torch.manual_seed() ):

https://github.com/stanford-crfm/mistral/blob/03a443718b3d150538e02ee88c2a20651bd6e19c/src/core/trainer.py#L225

Also, I modified train.py to return the trainer, so the tests can look at the trainer after train.py runs:

https://github.com/stanford-crfm/mistral/blob/03a443718b3d150538e02ee88c2a20651bd6e19c/train.py#L203
