### PR TITLE
set train_batch_size to auto

### DIFF
--- a/conf/deepspeed/z1-conf.json
+++ b/conf/deepspeed/z1-conf.json
@@ -30,5 +30,8 @@
     "overlap_comm": true,
     "contiguous_gradients": true,
     "cpu_offload": false
-  }
+  },
+
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto"
 }

--- a/conf/deepspeed/z2-medium-conf.json
+++ b/conf/deepspeed/z2-medium-conf.json
@@ -30,5 +30,8 @@
     "overlap_comm": true,
     "contiguous_gradients": true,
     "cpu_offload": false
-  }
+  },
+
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto"
 }

--- a/conf/deepspeed/z2-small-conf.json
+++ b/conf/deepspeed/z2-small-conf.json
@@ -30,5 +30,8 @@
     "overlap_comm": true,
     "contiguous_gradients": true,
     "cpu_offload": false
-  }
+  },
+
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto"
 }


### PR DESCRIPTION
It is necessary to set "train_batch_size" to "auto" when running training with deepspeed. This pull request updates a few of the deepspeed config files.