### PR TITLE
add defaults to cerberos schema to help keep wikitext-103 working.

### DIFF
--- a/conf/train_schema.py
+++ b/conf/train_schema.py
@@ -20,6 +20,13 @@ from quinine.common.cerberus import (
 )
 
 
+def _tlist_of(element_schema):
+    """
+    Returns a cerberus schema that validates a list of element_schema.
+    """
+    return {"type": "list", "schema": element_schema}
+
+
 def get_schema() -> Dict[str, Any]:
     """Get the Cerberus schema for the Quinine config used in train.py."""
 
@@ -32,6 +39,8 @@ def get_schema() -> Dict[str, Any]:
         "eval_num_proc": merge(tinteger, default(4)),
         "dataset_dir": merge(tstring, nullable, default(None)),
         "detokenize": merge(tboolean, default(True)),
+        "source": merge(tstring, default("hub")),
+        "source_ratios": merge(_tlist_of(tfloat), nullable, default(None)),
     }
 
     # Schema for Model


### PR DESCRIPTION
Was trying to keep wikitext 103 working as a warmup. needed to add some defaults. Still not quite working--HF doesn't like interleave_datasets on DatasetDict--but seems like a necessary first step.

## Description

add schema to support the new arguments for source and ratio

## Unit test coverage
Are there unit tests in place to make sure your code is functioning correctly?

none.

## Known breaking changes/behaviors
Does this break anything in Mistral's existing user interface? If so, what is it and how is it addressed?
