### PR TITLE
move gradient_checkpointing over to training_arguments since it's now…

### DIFF
--- a/conf/models/gpt2-medium.yaml
+++ b/conf/models/gpt2-medium.yaml
@@ -4,9 +4,6 @@
 model:
     id: "gpt2-medium"
 
-    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
-    gradient_checkpointing: false
-
     # Boolean whether to use the pre-existing Hugging Face AutoTokenizer (or train a new one from scratch)
     pretrained_tokenizer: true
 

--- a/conf/models/gpt2-micro.json
+++ b/conf/models/gpt2-micro.json
@@ -7,7 +7,6 @@
   "bos_token_id": 50256,
   "embd_pdrop": 0.1,
   "eos_token_id": 50256,
-  "gradient_checkpointing": false,
   "initializer_range": 0.02,
   "layer_norm_epsilon": 1e-05,
   "model_type": "gpt2",

--- a/conf/models/gpt2-micro.yaml
+++ b/conf/models/gpt2-micro.yaml
@@ -4,9 +4,6 @@
 model:
     id: "gpt2-small"
 
-    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
-    gradient_checkpointing: false
-
     # Boolean whether to use the pre-existing Hugging Face AutoTokenizer (or train a new one from scratch)
     pretrained_tokenizer: true
 

--- a/conf/models/gpt2-small.yaml
+++ b/conf/models/gpt2-small.yaml
@@ -4,9 +4,6 @@
 model:
     id: "gpt2-small"
 
-    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
-    gradient_checkpointing: false
-
     # Boolean whether to use the pre-existing Hugging Face AutoTokenizer (or train a new one from scratch)
     pretrained_tokenizer: true
 

--- a/conf/train_schema.py
+++ b/conf/train_schema.py
@@ -3,6 +3,7 @@ train_schema.py
 
 Cerberus schema used by Quinine for train.py.
 """
+import logging
 from typing import Any, Dict
 
 from quinine.common.cerberus import (
@@ -20,6 +21,16 @@ from quinine.common.cerberus import (
 )
 
 
+def deprecated_field(msg):
+    """Can be used in a schema to indicate that a field has been deprecated."""
+    def _deprecated_field(field, value, _error):
+        if value is not None:
+            logging.warning(f"{field} is deprecated and will be removed in a future release.")
+            if msg:
+                logging.warning(msg)
+    return {"check_with": _deprecated_field}
+
+
 def get_schema() -> Dict[str, Any]:
     """Get the Cerberus schema for the Quinine config used in train.py."""
 
@@ -35,7 +46,8 @@ def get_schema() -> Dict[str, Any]:
     # Schema for Model
     model_schema = {
         "id": merge(tstring, required),
-        "gradient_checkpointing": merge(tboolean, default(False)),
+        "gradient_checkpointing": merge(tboolean, nullable, default(None),
+                                        deprecated_field("This config is now in training_arguments to better match HF.")),
         "pretrained_tokenizer": merge(tboolean, default(True)),
         "seq_len": merge(tinteger, default(1024)),
         "reorder_and_upcast_attn": merge(tboolean, nullable, default(True)),
@@ -76,6 +88,7 @@ def get_schema() -> Dict[str, Any]:
         "deepspeed": merge(tstring, nullable, default(None)),
         "dataloader_num_workers": merge(tinteger, default(4)),
         "local_rank": merge(tinteger, nullable, default(None)),
+        "gradient_checkpointing": merge(tboolean, default(False)),
     }
 
     # Schema for Online Custom Evaluation Datasets (e.g. LAMBADA)

--- a/conf/trainers/gpt2-medium.yaml
+++ b/conf/trainers/gpt2-medium.yaml
@@ -19,6 +19,10 @@ training_arguments:
     # We set this dynamically based on DDP Computation [steps = effective_batch / (per_gpu_batch * gpus * nodes)]
     gradient_accumulation_steps: null
 
+    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
+    gradient_checkpointing: false
+
+
     # For Online Evaluation, only keep around the Losses
     prediction_loss_only: true
 

--- a/conf/trainers/gpt2-small.yaml
+++ b/conf/trainers/gpt2-small.yaml
@@ -19,6 +19,9 @@ training_arguments:
     # We set this dynamically based on DDP Computation [steps = effective_batch / (per_gpu_batch * gpus * nodes)]
     gradient_accumulation_steps: null
 
+    # Boolean whether to use Gradient Checkpointing to save GPU Memory at the expense of runtime
+    gradient_checkpointing: false
+
     # For Online Evaluation, only keep around the Losses
     prediction_loss_only: true
 

--- a/src/args/training_args.py
+++ b/src/args/training_args.py
@@ -7,6 +7,7 @@ accumulation).
 """
 import logging
 from pathlib import Path
+from typing import Optional
 
 from munch import Munch
 from transformers import TrainingArguments
@@ -25,6 +26,7 @@ def get_training_arguments(
     effective_bsz: int = 512,
     nodes: int = 1,
     gpus_per_node: int = 8,
+    gradient_checkpointing: Optional[bool] = None,
 ) -> TrainingArguments:
     """Initialize Training Arguments from Quinfig and Runtime-Defined Variables."""
 
@@ -38,6 +40,10 @@ def get_training_arguments(
 
     # Since we Implement a Custom W&B / JSON Logging Callback, we don't report to anyone -- we've gone rogue!
     training_args.report_to = "none"
+
+    # do it this way so we start supporting gradient_checkpointing in training_args à la Transformers
+    if gradient_checkpointing is not None:
+        training_args.gradient_checkpointing = gradient_checkpointing
 
     # If "sharded_ddp" is None --> replace with False
     if training_args.sharded_ddp is None:

--- a/src/models/auto_clm.py
+++ b/src/models/auto_clm.py
@@ -52,10 +52,14 @@ def get_auto_clm_tokenizer(
         overwatch.error("Tokenizer Training/Initialization (from Scratch) not yet implemented!")
         raise NotImplementedError()
 
-    model_desc = "Custom GPT-2" if "gpt2" in model_id else "Tabula Rasa"
-    overwatch.info(f"Initializing {model_desc} Model from Configuration: `{REGISTRY[model_id]}`...")
+    if "gpt2" in model_id:
+        overwatch.info(f"Initializing Custom GPT-2 Model from Configuration: `{REGISTRY[model_id]}`...")
+        model = GPT2LMHeadModel(config)
+    else:
+        # Initialize Model
+        overwatch.info(f"Initializing Tabula Rasa Model from Configuration: `{REGISTRY[model_id]}`...")
+        model = AutoModelForCausalLM.from_config(config)
 
-    model = AutoModelForCausalLM.from_config(config)
 
     # Run GPT-Specific Initialization, if applicable
     model.resize_token_embeddings(len(tokenizer))

--- a/src/models/auto_clm.py
+++ b/src/models/auto_clm.py
@@ -24,7 +24,6 @@ def get_auto_clm_tokenizer(
     model_id: str,
     paths: Dict[str, Path],
     model_configs: dict = None,
-    gradient_checkpointing: bool = True,
     use_pretrained_tokenizer: bool = True,
     reorder_and_upcast_attn: bool = True,
     scale_attn_by_inverse_layer_idx: bool = True,
@@ -53,18 +52,10 @@ def get_auto_clm_tokenizer(
         overwatch.error("Tokenizer Training/Initialization (from Scratch) not yet implemented!")
         raise NotImplementedError()
 
-    # Partial Gradient Checkpointing (currently only supported for GPT-2 models)
-    if "gpt2" in model_id:
-        overwatch.info(f"Initializing Custom GPT-2 Model from Configuration: `{REGISTRY[model_id]}`...")
-        model = GPT2LMHeadModel(config)
-        if gradient_checkpointing:
-            model.gradient_checkpointing_enable()
+    model_desc = "Custom GPT-2" if "gpt2" in model_id else "Tabula Rasa"
+    overwatch.info(f"Initializing {model_desc} Model from Configuration: `{REGISTRY[model_id]}`...")
 
-    # No Adaptive Gradient Checkpointing
-    else:
-        # Initialize Model
-        overwatch.info(f"Initializing Tabula Rasa Model from Configuration: `{REGISTRY[model_id]}`...")
-        model = AutoModelForCausalLM.from_config(config)
+    model = AutoModelForCausalLM.from_config(config)
 
     # Run GPT-Specific Initialization, if applicable
     model.resize_token_embeddings(len(tokenizer))

--- a/train.py
+++ b/train.py
@@ -94,7 +94,6 @@ def train() -> OnlineBenchmarkTrainer:
         quinfig.model.id,
         paths,
         model_configs=model_configs,
-        gradient_checkpointing=quinfig.model.gradient_checkpointing,
         use_pretrained_tokenizer=quinfig.model.pretrained_tokenizer,
         reorder_and_upcast_attn=quinfig.model.reorder_and_upcast_attn,
         scale_attn_by_inverse_layer_idx=quinfig.model.scale_attn_by_inverse_layer_idx,
@@ -146,6 +145,7 @@ def train() -> OnlineBenchmarkTrainer:
         effective_bsz=quinfig.effective_bsz,
         nodes=quinfig.nnodes,
         gpus_per_node=quinfig.nproc_per_node,
+        gradient_checkpointing=quinfig.model.gradient_checkpointing,
     )
 
     # Initialize Trainer, with the relevant arguments


### PR DESCRIPTION
… baked into HF.

## Description

gradient_checkpointing was special cased in auto_clm, but it's now natively supported by HuggingFace in TrainingArguments, so may as well move it in there.

## Unit test coverage

I made sure the deprecation warning did the expected thing.

## Known breaking changes/behaviors

Deprecates rather than removes gradient_checkpointing from the model config, so I don't think it should break anything.

