### PR TITLE
[Low Priority/Optional] allow export to support more than two archs

### DIFF
--- a/environments/environment-m1.yaml
+++ b/environments/environment-m1.yaml
@@ -1,0 +1,98 @@
+name: mistral
+channels:
+- ngam
+- conda-forge
+dependencies:
+- ca-certificates=2021.10.8
+- cffi=1.15.0
+- future=0.18.2
+- libblas=3.9.0
+- libcblas=3.9.0
+- libcxx=12.0.1
+- libffi=3.4.2
+- libgfortran=5.0.0.dev0
+- libgfortran5=11.0.1.dev0
+- liblapack=3.9.0
+- libopenblas=0.3.18
+- libprotobuf=3.19.4
+- libzlib=1.2.11
+- llvm-openmp=13.0.1
+- ncurses=6.3
+- numpy=1.22.2
+- openssl=3.0.0
+- pip=22.0.3
+- pycparser=2.21
+- python=3.8.12
+- python_abi=3.8
+- pytorch=1.10.0
+- readline=8.1
+- setuptools=60.9.3
+- sleef=3.5.1
+- sqlite=3.37.0
+- tk=8.6.12
+- torchaudio=0.10.0
+- typing_extensions=4.1.1
+- wheel=0.37.1
+- xz=5.2.5
+- zlib=1.2.11
+- pip:
+  - aiohttp==3.8.1
+  - aiosignal==1.2.0
+  - async-timeout==4.0.2
+  - attrs==21.4.0
+  - cerberus==1.3.2
+  - certifi==2021.10.8
+  - charset-normalizer==2.0.12
+  - click==8.0.4
+  - cytoolz==0.11.0
+  - datasets==1.18.3
+  - deepspeed==0.5.10
+  - dill==0.3.4
+  - docker-pycreds==0.4.0
+  - filelock==3.6.0
+  - frozenlist==1.3.0
+  - fsspec==2022.2.0
+  - funcy==1.15
+  - gin-config==0.3.0
+  - gitdb==4.0.9
+  - gitpython==3.1.27
+  - hjson==3.0.2
+  - huggingface-hub==0.4.0
+  - idna==3.3
+  - joblib==1.1.0
+  - jsonlines==3.0.0
+  - multidict==6.0.2
+  - multiprocess==0.70.12.2
+  - munch==2.5.0
+  - ninja==1.10.2.3
+  - packaging==21.3
+  - pandas==1.4.1
+  - pathtools==0.1.2
+  - promise==2.3
+  - protobuf==3.19.4
+  - psutil==5.9.0
+  - py-cpuinfo==8.0.0
+  - pyarrow==7.0.0
+  - pyparsing==3.0.7
+  - python-dateutil==2.8.2
+  - pytz==2021.3
+  - pyyaml==5.4
+  - quinine==0.3.0
+  - regex==2022.1.18
+  - requests==2.27.1
+  - sacremoses==0.0.47
+  - sentry-sdk==1.5.6
+  - shortuuid==1.0.8
+  - six==1.16.0
+  - smmap==5.0.0
+  - termcolor==1.1.0
+  - tokenizers==0.11.5
+  - toolz==0.11.2
+  - toposort==1.5
+  - tqdm==4.62.3
+  - git+https://github.com/huggingface/transformers
+  - urllib3==1.26.8
+  - wandb==0.12.10
+  - xxhash==3.0.0
+  - yarl==1.7.2
+  - yaspin==2.1.0

--- a/environments/export.py
+++ b/environments/export.py
@@ -21,11 +21,10 @@ MAP = {
 
 
 def export() -> None:
-    # Default & Simple Argparse --> Just takes one argument :: `arch` in < cpu | gpu >
+    # Default & Simple Argparse --> Just takes one argument :: `arch` (typically < cpu | gpu >)
     parser = argparse.ArgumentParser(description="Export Conda Environment for the Given Architecture.")
-    parser.add_argument("-a", "--arch", default="gpu", type=str, help="Architecture in < cpu | gpu >.")
+    parser.add_argument("-a", "--arch", type=str, help="Architecture in < cpu | gpu | m1 >.")
     args = parser.parse_args()
-    assert args.arch in ["cpu", "gpu"], f"Architecture `{args.arch}` not defined - try one of < cpu | gpu >!"
 
     # Remove existing environment.yaml
     environment_yaml = Path("environments", f"environment-{args.arch}.yaml")


### PR DESCRIPTION
## Description

the cpu env doesn't build on an m1 macbook with native (non-rosetta'd), so i just unlocked the arch parameter. I dunno if we want to do this, or to commit an m1 file, but figured i'd toss it out there.
