### PR TITLE
Local tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ from src.core.trainer import OnlineBenchmarkTrainer
 from train import train
 
 
-MISTRAL_TEST_DIR = os.getenv("MISTRAL_TEST_DIR")
+MISTRAL_TEST_DIR = os.getenv("MISTRAL_TEST_DIR") or "."
 
 # standard utils
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
 
 
@@ -9,7 +11,7 @@ TRAIN_ARGS = {
     "nnodes": "1",
     "nproc_per_node": "1",
     "config": "conf/train.yaml",
-    "training_arguments.fp16": "true",
+    "training_arguments.fp16": "false",
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "log_level": "50",
@@ -19,17 +21,8 @@ TRAIN_ARGS = {
 
 trainer_w_train = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
 
-TRAIN_ARGS_DIFF = {
-    "nnodes": "1",
-    "nproc_per_node": "1",
-    "config": "conf/train-diff.yaml",
-    "training_arguments.fp16": "true",
-    "training_arguments.per_device_train_batch_size": "1",
-    "artifacts.cache_dir": CACHE_DIR,
-    "log_level": "50",
-    "run_training": "false",
-    "run_final_eval": "false",
-}
+TRAIN_ARGS_DIFF = copy(TRAIN_ARGS)
+TRAIN_ARGS_DIFF["config"] = "conf/train-diff.yaml"
 
 trainer_w_train_diff = run_train_process(
     cl_args_dict=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR, run_id="train_args_diff_test"

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -14,7 +14,7 @@ TRAIN_ARGS_SEED_7 = {
     "nnodes": "1",
     "nproc_per_node": "1",
     "config": "conf/train.yaml",
-    "training_arguments.fp16": "true",
+    "training_arguments.fp16": "false",
     "training_arguments.per_device_train_batch_size": "1",
     "artifacts.cache_dir": CACHE_DIR,
     "seed": "7",
@@ -37,7 +37,6 @@ def is_randomized(key):
     weights and biases, and bias terms in general.
     """
     # regexes for components that are not randomized
-    print(key)
     if key.endswith("bias") or "ln" in key:
         return False
     else:


### PR DESCRIPTION
Make it so I can run almost all tests locally on an M1 macbook.

Changes:

* use fp32 training instead. I didn't change the test_fp test (though I'm honestly not sure what that test is testing since there are no asserts)
* don't rely on env variable for MISTRAL_TEST_DIR (otherwise it uses "None" as a path name!)
* make it so wandb can be removed if the standard env variable is set. I ran into some dumb issues I still don't understand
* one test needs num_workers=0. I don't know why and it's impossible to debug.