### PR TITLE
Fork Preprocessing when doing multiple gpus

### DIFF
--- a/src/corpora/auto.py
+++ b/src/corpora/auto.py
@@ -189,7 +189,7 @@ def get_lambada(
 
         beginning_tokens, last_token = tokenizer.encode(text[:start_idx].strip()), tokenizer.encode(" " + last_token)
         num_pad = seq_len - len(beginning_tokens) - len(last_token)
-        assert num_pad >= 0, "LAMBADA example is shorter than sequence length, will result in error."
+        assert num_pad >= 0, "LAMBADA example is longer than sequence length, will result in error."
 
         input_ids = beginning_tokens + last_token + [tokenizer.eos_token_id for _ in range(num_pad)]
         labels = [-100 for _ in beginning_tokens] + [tok for tok in last_token] + [-100 for _ in range(num_pad)]

--- a/src/corpora/auto.py
+++ b/src/corpora/auto.py
@@ -44,7 +44,6 @@ def get_auto_dataset(
         assert "train" in dataset, "You must have train in dataset to make a validation dataset"
         # Create Dataset Split Cache Files
         train_fn, val_fn = [str(paths["dataset"] / dataset_id / f"{k}-split.hf") for k in ["train", "val"]]
-
         dataset = dataset["train"].train_test_split(
             test_size=validation_ratio,
             train_indices_cache_file_name=train_fn,
@@ -79,7 +78,8 @@ def get_auto_dataset(
     tokenized_dataset = dataset.map(
         tokenize,
         batched=True,
-        num_proc=1, # tokenization is
+        # tokenization is parallelized by huggingface's fast tokenizers
+        num_proc=1 if tokenizer.is_fast else preprocessing_num_proc,
         remove_columns=next(iter(dataset.values())).column_names,
         cache_file_names=post_tokenization_cache_files,
         load_from_cache_file=True,

--- a/src/corpora/auto.py
+++ b/src/corpora/auto.py
@@ -7,7 +7,7 @@ de-facto training, validation, and testing tests. Performs additional tokenizati
 import logging
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 import datasets
 from transformers import BatchEncoding, PreTrainedTokenizer
@@ -29,6 +29,7 @@ def get_auto_dataset(
     preprocessing_num_proc: int = 64,
     stride: int = -1,
     ignore_train: bool = False,
+    _actual_preprocessing: bool = False
 ) -> datasets.DatasetDict:
     """Run basic tokenization and grouping to turn a Hugging Face Dataset (via `datasets`) into a torch.Dataset."""
 
@@ -43,6 +44,7 @@ def get_auto_dataset(
         assert "train" in dataset, "You must have train in dataset to make a validation dataset"
         # Create Dataset Split Cache Files
         train_fn, val_fn = [str(paths["dataset"] / dataset_id / f"{k}-split.hf") for k in ["train", "val"]]
+
         dataset = dataset["train"].train_test_split(
             test_size=validation_ratio,
             train_indices_cache_file_name=train_fn,
@@ -77,7 +79,7 @@ def get_auto_dataset(
     tokenized_dataset = dataset.map(
         tokenize,
         batched=True,
-        num_proc=preprocessing_num_proc,
+        num_proc=1, # tokenization is
         remove_columns=next(iter(dataset.values())).column_names,
         cache_file_names=post_tokenization_cache_files,
         load_from_cache_file=True,
@@ -167,6 +169,7 @@ def get_lambada(
     preprocessing_num_proc: int = 4,
     stride: int = -1,
     ignore_train: bool = False,
+    _actual_preprocessing: bool = False
 ) -> datasets.DatasetDict:
     """
     Run special tokenization and grouping for the Lambada dataset.

--- a/src/corpora/auto.py
+++ b/src/corpora/auto.py
@@ -29,7 +29,6 @@ def get_auto_dataset(
     preprocessing_num_proc: int = 64,
     stride: int = -1,
     ignore_train: bool = False,
-    _actual_preprocessing: bool = False
 ) -> datasets.DatasetDict:
     """Run basic tokenization and grouping to turn a Hugging Face Dataset (via `datasets`) into a torch.Dataset."""
 

--- a/src/corpora/auto.py
+++ b/src/corpora/auto.py
@@ -169,7 +169,6 @@ def get_lambada(
     preprocessing_num_proc: int = 4,
     stride: int = -1,
     ignore_train: bool = False,
-    _actual_preprocessing: bool = False
 ) -> datasets.DatasetDict:
     """
     Run special tokenization and grouping for the Lambada dataset.

--- a/train.py
+++ b/train.py
@@ -48,16 +48,6 @@ def train() -> OnlineBenchmarkTrainer:
     print('\t=>> "This wind, it is not an ending..." (Robert Jordan - A Memory of Light)')
     quinfig = QuinineArgumentParser(schema=get_schema()).parse_quinfig()
 
-    # hack-y hack hack, set the default pg timeout to 6 hours
-    try:
-        import torch.distributed.constants
-        torch.distributed.constants.default_pg_timeout = timedelta(hours=6)
-        import deepspeed.constants
-        deepspeed.constants.default_pg_timeout = timedelta(hours=6)
-    except ModuleNotFoundError:
-        print("[!] Mercury :: Unable to import distributed modules")
-
-
     # Set Distributed Arguments
     # TODO train.A :: @Laurel, @Karan -- `local_rank` not in Quinfig w/ torch.distributed.launch?
     quinfig.world_size = int(os.getenv("WORLD_SIZE", quinfig.nproc_per_node))

--- a/train.py
+++ b/train.py
@@ -31,6 +31,7 @@ from typing import Optional
 import numpy as np
 import torch
 from quinine import QuinineArgumentParser
+from transformers import default_data_collator
 from transformers.trainer_utils import get_last_checkpoint
 
 from conf.train_schema import get_schema

--- a/train.py
+++ b/train.py
@@ -20,15 +20,17 @@ Reference:
 
 |=>> A Project Mercury Endeavor
 """
+import copy
 import json
 import os
 import random
+import time
 from datetime import datetime
+from typing import Optional
 
 import numpy as np
 import torch
 from quinine import QuinineArgumentParser
-from transformers.data.data_collator import default_data_collator
 from transformers.trainer_utils import get_last_checkpoint
 
 from conf.train_schema import get_schema
@@ -45,6 +47,16 @@ def train() -> OnlineBenchmarkTrainer:
     print("[*] Mercury :: Launching =>>> \N{rocket} \N{see-no-evil monkey} \N{rocket}")
     print('\t=>> "This wind, it is not an ending..." (Robert Jordan - A Memory of Light)')
     quinfig = QuinineArgumentParser(schema=get_schema()).parse_quinfig()
+
+    # hack-y hack hack, set the default pg timeout to 6 hours
+    try:
+        import torch.distributed.constants
+        torch.distributed.constants.default_pg_timeout = timedelta(hours=6)
+        import deepspeed.constants
+        deepspeed.constants.default_pg_timeout = timedelta(hours=6)
+    except ModuleNotFoundError:
+        print("[!] Mercury :: Unable to import distributed modules")
+
 
     # Set Distributed Arguments
     # TODO train.A :: @Laurel, @Karan -- `local_rank` not in Quinfig w/ torch.distributed.launch?
@@ -100,39 +112,6 @@ def train() -> OnlineBenchmarkTrainer:
         initial_weights=quinfig.model.initial_weights,
     )
 
-    # Load Dataset w/ Preprocessing, Batching, and Collating
-    overwatch.info(f"Downloading and Preprocessing Dataset `{quinfig.dataset.id}`...")
-    lm_dataset = get_auto_dataset(
-        tokenizer,
-        paths,
-        dataset_id=quinfig.dataset.id,
-        dataset_name=quinfig.dataset.name,
-        validation_ratio=quinfig.dataset.validation_ratio,
-        seq_len=quinfig.model.seq_len,
-        preprocessing_num_proc=quinfig.dataset.num_proc,
-    )
-
-    # Load Online Eval Datasets
-    custom_eval_datasets = dict()
-    for eval_dataset_arg in list(filter(lambda x: x.startswith("do_"), quinfig.online_eval.keys())):
-        if getattr(quinfig.online_eval, eval_dataset_arg):
-            # Dataset name is in quinfig arg of "do_<dataset>" -> Boolean
-            dataset_name = eval_dataset_arg.lstrip("do_")
-            overwatch.info(f"Downloading and Preprocessing Online Eval Dataset {dataset_name}")
-            custom_eval_datasets[dataset_name] = ONLINE_EVAL_DATA_REGISTRY[dataset_name]["generator"](
-                tokenizer,
-                paths,
-                dataset_id=ONLINE_EVAL_DATA_REGISTRY[dataset_name]["id"],
-                dataset_name=ONLINE_EVAL_DATA_REGISTRY[dataset_name]["name"],
-                validation_ratio=quinfig.dataset.validation_ratio,
-                seq_len=quinfig.model.seq_len,
-                stride=quinfig.online_eval.stride,
-                preprocessing_num_proc=quinfig.dataset.eval_num_proc,
-                ignore_train=True,
-            )["validation"]
-
-    # Fix All Dataset Permissions
-    set_permissions(paths)
 
     # Initialize Training Arguments from Quinfig
     overwatch.info("Setting Training Arguments from Quinfig...")
@@ -147,6 +126,16 @@ def train() -> OnlineBenchmarkTrainer:
         gpus_per_node=quinfig.nproc_per_node,
         gradient_checkpointing=quinfig.model.gradient_checkpointing,
     )
+
+    # ensures deepspeed is initialized
+    training_args._setup_devices
+
+    # Load Dataset w/ Preprocessing, Batching, and Collating
+    custom_eval_datasets, lm_dataset = load_datasets(quinfig, paths, tokenizer, overwatch)
+
+    # Fix All Dataset Permissions
+    set_permissions(paths)
+
 
     # Initialize Trainer, with the relevant arguments
     overwatch.info("Initializing Model Trainer...")
@@ -207,6 +196,78 @@ def train() -> OnlineBenchmarkTrainer:
 
     # return trainer as record of training process
     return trainer
+
+
+def load_datasets(quinfig, paths, tokenizer, overwatch):
+    if quinfig.world_size > 1:
+        overwatch.info("Distributed Training detected. Forking preprocessing on 0th local rank...")
+        _preprocess_once_per_machine(quinfig, paths, tokenizer, overwatch)
+
+    overwatch.info(f"Downloading and Preprocessing Dataset `{quinfig.dataset.id}`...")
+    lm_dataset = get_auto_dataset(
+        tokenizer,
+        paths,
+        dataset_id=quinfig.dataset.id,
+        dataset_name=quinfig.dataset.name,
+        validation_ratio=quinfig.dataset.validation_ratio,
+        seq_len=quinfig.model.seq_len,
+        preprocessing_num_proc=quinfig.dataset.num_proc,
+    )
+    # Load Online Eval Datasets
+    custom_eval_datasets = dict()
+    for eval_dataset_arg in list(filter(lambda x: x.startswith("do_"), quinfig.online_eval.keys())):
+        if getattr(quinfig.online_eval, eval_dataset_arg):
+            # Dataset name is in quinfig arg of "do_<dataset>" -> Boolean
+            dataset_name = eval_dataset_arg.lstrip("do_")
+            overwatch.info(f"Downloading and Preprocessing Online Eval Dataset {dataset_name}")
+            custom_eval_datasets[dataset_name] = ONLINE_EVAL_DATA_REGISTRY[dataset_name]["generator"](
+                tokenizer,
+                paths,
+                dataset_id=ONLINE_EVAL_DATA_REGISTRY[dataset_name]["id"],
+                dataset_name=ONLINE_EVAL_DATA_REGISTRY[dataset_name]["name"],
+                validation_ratio=quinfig.dataset.validation_ratio,
+                seq_len=quinfig.model.seq_len,
+                stride=quinfig.online_eval.stride,
+                preprocessing_num_proc=quinfig.dataset.eval_num_proc,
+                ignore_train=True,
+            )["validation"]
+    return custom_eval_datasets, lm_dataset
+
+
+def _preprocess_once_per_machine(quinfig, paths, tokenizer, overwatch):
+    assert quinfig.world_size > 1, "Shouldn't have forked if world_size is 1"
+    import torch.distributed as dist
+
+    # create a group for all ranks on this machine (on the annoying assumption that all machines have the same number of devices running)
+    # TODO: this will not work w/ tpus I think?
+    cur_group, subgroups = dist.new_subgroups()
+    import multiprocessing as mp
+    process: Optional[mp.Process] = None
+    if cur_group.rank() == 0:
+        # fork a process and do a sleep/wait for other processes to finish loading
+        cloned_config = copy.deepcopy(quinfig)
+        cloned_config.local_rank = 0
+        cloned_config.world_size = 1
+        process = mp.Process(target=load_datasets, args=(cloned_config, paths, tokenizer, overwatch))
+        process.start()
+
+    while True:
+        status = [None]
+        if cur_group.rank() == 0:
+            status = [process.exitcode]
+
+        dist.broadcast_object_list(status, src=0)
+        if status[0] is not None:
+            break
+
+        time.sleep(10)
+
+    if status[0] != 0:
+        raise RuntimeError(f"Forked process exited with status {status[0]}")
+
+    dist.barrier()  # make sure everyone makes it
+    for subgroup in subgroups:
+        dist.destroy_process_group(subgroup)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #117

So, as hypothesized in #126  by @jthickstun, parallelized preprocessing was leading to major problems, particularly as one added more GPUs. To mitigate this, I've now made it so that preprocessing is forked into a single separate process per-machine (I'm assuming we're using local file systems for caches)