### PR TITLE
make CI keep up with dependencies, discover tests automatically, validate configs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,7 +12,12 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: Setup
+      - name: Setting up Environment
+        run: |
+          conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
+          conda activate mistral-${{github.sha}}
+          pip install -r requirements.txt
+      - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'
           cd tests ; wandb disabled
@@ -23,5 +28,10 @@ jobs:
         run: |
           cd tests
           CUDA_VISIBLE_DEVICES=0 pytest --durations=0
+      - name: Delete conda environment
+        if: always()
+        run: |
+          conda deactivate
+          conda env remove -n mistral-${{github.sha}}
       - run: echo "All tests finished!"
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Setting up Conda Environment
         run: |
           echo "Setting up conda env for this test!"
+          echo "which conda:"
           which conda
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,6 +14,7 @@ jobs:
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: Setting up Conda Environment
         run: |
+          echo "Setting up conda env for this test!"
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,14 +18,13 @@ jobs:
           echo "which conda:"
           which conda
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
-          conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
+          conda create -n mistral-${{github.sha}} --file setup/conda-requirements.txt -c pytorch
           conda activate mistral-${{github.sha}}
       - name: Installing dependencies
         run: |
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda activate mistral-${{github.sha}}
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -r setup/pip-requirements.txt
       - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,13 +12,13 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: Setting up Environment
+      - name: Setting up Conda Environment
         run: |
-          echo $SHELL
-          conda init bash
+          eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}
-          pip install -r requirements.txt
+      - name: Installing dependencies
+        run: pip install -r requirements.txt
       - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'
@@ -26,7 +26,6 @@ jobs:
           echo 'MISTRAL_TEST_DIR:'
           echo $MISTRAL_TEST_DIR
       - name: Run tests (single node/single GPU)
-        if: always()
         run: |
           cd tests
           CUDA_VISIBLE_DEVICES=0 pytest --durations=0

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,6 +14,8 @@ jobs:
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: Setting up Environment
         run: |
+          echo $SHELL
+          conda init bash
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}
           pip install -r requirements.txt

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Setting up Conda Environment
         run: |
           echo "Setting up conda env for this test!"
+          which conda
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,25 +18,10 @@ jobs:
           cd tests ; wandb disabled
           echo 'MISTRAL_TEST_DIR:'
           echo $MISTRAL_TEST_DIR
-      - name: Tests for arguments (single node/single GPU)
+      - name: Run tests (single node/single GPU)
         if: always()
         run: |
           cd tests
-          CUDA_VISIBLE_DEVICES=0 pytest test_args.py
-      - name: Tests for checkpoints (single node/single GPU)
-        if: always()
-        run: |
-          cd tests
-          CUDA_VISIBLE_DEVICES=0 pytest test_checkpoint.py
-      - name: Tests for upcasting (single node/single GPU)
-        if: always()
-        run: |
-          cd tests
-          CUDA_VISIBLE_DEVICES=0 pytest test_fp.py
-      - name: Tests for random seed (single node/single GPU)
-        if: always()
-        run: |
-          cd tests
-          CUDA_VISIBLE_DEVICES=0 pytest test_seed.py
+          CUDA_VISIBLE_DEVICES=0 pytest --durations=0
       - run: echo "All tests finished!"
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,8 +15,6 @@ jobs:
       - name: Setting up Conda Environment
         run: |
           echo "Setting up conda env for this test!"
-          echo "which conda:"
-          which conda
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda create -n mistral-${{github.sha}} --file setup/conda-requirements.txt -c pytorch
           conda activate mistral-${{github.sha}}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'
+          eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
+          conda activate mistral-${{github.sha}}
           cd tests ; wandb disabled
           echo 'MISTRAL_TEST_DIR:'
           echo $MISTRAL_TEST_DIR

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,7 +18,7 @@ jobs:
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}
       - name: Installing dependencies
-        run:
+        run: |
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda activate mistral-${{github.sha}}
           pip install -r requirements.txt

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -25,6 +25,7 @@ jobs:
           eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda activate mistral-${{github.sha}}
           pip install -r requirements.txt
+          pip install pytest
       - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,7 +18,10 @@ jobs:
           conda create -n mistral-${{github.sha}} python=3.8 pytorch torchdata cudatoolkit=10.2 -c pytorch
           conda activate mistral-${{github.sha}}
       - name: Installing dependencies
-        run: pip install -r requirements.txt
+        run:
+          eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
+          conda activate mistral-${{github.sha}}
+          pip install -r requirements.txt
       - name: Setting up environment variables
         run: |
           echo 'Deactivating wandb'
@@ -27,11 +30,14 @@ jobs:
           echo $MISTRAL_TEST_DIR
       - name: Run tests (single node/single GPU)
         run: |
+          eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
+          conda activate mistral-${{github.sha}}
           cd tests
           CUDA_VISIBLE_DEVICES=0 pytest --durations=0
       - name: Delete conda environment
         if: always()
         run: |
+          eval "$(conda 'shell.bash' 'hook' 2>/dev/null)" # make conda happy
           conda deactivate
           conda env remove -n mistral-${{github.sha}}
       - run: echo "All tests finished!"

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Mistral has been tested with Python 3.8.12, PyTorch 1.11.0 (compiled with CUDA 1
 The environment can be easily built with the following commands:
 
 ```bash
-conda create -n mistral python=3.8.12
+conda create -n mistral python=3.8.12 pytorch torchdata cudatoolkit=11.3 -c pytorch
 conda activate mistral
-conda install pytorch cudatoolkit=11.3 -c pytorch
-pip install -r requirements.txt
+pip install -r setup/pip-requirements.txt
 ```
 
 A `.yaml` export of a tested environment is provided at `environments/environment-gpu.yaml`.

--- a/conf/datasets/wikitext103.yaml
+++ b/conf/datasets/wikitext103.yaml
@@ -4,7 +4,6 @@
 dataset:
     id: wikitext
     name: wikitext-103-raw-v1
-    validation_ratio: null
 
     # Number of Preprocessing Workers
     num_proc: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-datasets==2.0.0
-deepspeed==0.6.0
-huggingface-hub==0.4.0
-jsonlines==3.0.0
-quinine==0.3.0
-transformers==4.18.0
-wandb==0.12.11

--- a/setup/conda-requirements.txt
+++ b/setup/conda-requirements.txt
@@ -1,0 +1,4 @@
+python=3.8.12
+pytorch
+torchdata
+cudatoolkit=10.2.89

--- a/setup/pip-requirements.txt
+++ b/setup/pip-requirements.txt
@@ -1,0 +1,7 @@
+datasets==2.0.0
+deepspeed==0.6.0
+huggingface-hub==0.4.0
+jsonlines==3.0.0
+quinine==0.3.0
+transformers==4.18.0
+wandb==0.12.11

--- a/setup/pip-requirements.txt
+++ b/setup/pip-requirements.txt
@@ -2,6 +2,7 @@ datasets==2.0.0
 deepspeed==0.6.0
 huggingface-hub==0.4.0
 jsonlines==3.0.0
+pytest==7.1.2
 quinine==0.3.0
 transformers==4.18.0
 wandb==0.12.11

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,11 +1,15 @@
 #!/bin/sh
 
 if  [ "$CONDA_DEFAULT_ENV" != "base" ]; then
-    echo "Error: run setup from (base) environment!"
+    echo "Error: run setup from base environment!"
     exit
 fi
+echo "Creating mistral conda environment!"
 conda create -y -n mistral --file conda-requirements.txt -c pytorch
 . $CONDA_PREFIX/etc/profile.d/conda.sh
 conda activate mistral
-pip install -r pip-requirements.txt
-echo "Successfully created (mistral) !!"
+if [ "$CONDA_DEFAULT_ENV" = "mistral" ]; then
+    echo "Installing python dependencies with pip!" 
+    pip install -r pip-requirements.txt
+fi
+echo "Successfully created mistral environment!"

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,0 +1,4 @@
+conda create -n mistral --file conda-requirements.txt -c pytorch
+. $CONDA_PREFIX/etc/profile.d/conda.sh
+conda activate mistral
+pip install -r pip-requirements.txt

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
+if  [ "$CONDA_DEFAULT_ENV" != "base" ]; then
+    echo "Error: run setup from (base) environment!"
+    exit
+fi
 conda create -n mistral --file conda-requirements.txt -c pytorch
 . $CONDA_PREFIX/etc/profile.d/conda.sh
 conda activate mistral
 pip install -r pip-requirements.txt
+echo "Successfully created (mistral) !!"

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 conda create -n mistral --file conda-requirements.txt -c pytorch
 . $CONDA_PREFIX/etc/profile.d/conda.sh
 conda activate mistral

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -4,7 +4,7 @@ if  [ "$CONDA_DEFAULT_ENV" != "base" ]; then
     echo "Error: run setup from (base) environment!"
     exit
 fi
-conda create -n mistral --file conda-requirements.txt -c pytorch
+conda create -y -n mistral --file conda-requirements.txt -c pytorch
 . $CONDA_PREFIX/etc/profile.d/conda.sh
 conda activate mistral
 pip install -r pip-requirements.txt

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,6 @@
 import inspect
 import os
-import re
 import shutil
-import subprocess
 import sys
 import traceback
 from unittest.mock import patch
@@ -116,6 +114,8 @@ def run_tests():
     """
     if DEEPSPEED_MODE and not am_first_deepspeed_child():
         return
+    os.environ["WANDB_DISABLED"] = "true"
+
     test_functions = get_test_functions()
     passing_tests = []
     failing_tests = []

--- a/tests/conf/train-diff.yaml
+++ b/tests/conf/train-diff.yaml
@@ -55,6 +55,8 @@ log_level: 20
 seed: 40
 
 online_eval:
+    do_wikitext: false
+    do_lambada: false
     stride: 256
 
 run_training: false

--- a/tests/conf/train.yaml
+++ b/tests/conf/train.yaml
@@ -56,4 +56,6 @@ log_level: 20
 seed: 21
 
 online_eval:
+    do_wikitext: false
+    do_lambada: false
     stride: 256

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -19,14 +19,18 @@ TRAIN_ARGS = {
     "run_final_eval": "false",
 }
 
-trainer_w_train = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
-
 TRAIN_ARGS_DIFF = copy(TRAIN_ARGS)
 TRAIN_ARGS_DIFF["config"] = "conf/train-diff.yaml"
 
-trainer_w_train_diff = run_train_process(
-    cl_args_dict=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR, run_id="train_args_diff_test"
-)
+trainer_w_train = None
+trainer_w_train_diff = None
+
+
+def setup_module() -> None:
+    global trainer_w_train, trainer_w_train_diff
+    trainer_w_train = run_train_process(cl_args_dict=TRAIN_ARGS, runs_dir=RUNS_DIR, run_id="train_args_test")
+    trainer_w_train_diff = run_train_process(cl_args_dict=TRAIN_ARGS_DIFF, runs_dir=RUNS_DIR,
+                                             run_id="train_args_diff_test")
 
 
 def test_train_args() -> None:

--- a/tests/test_fp.py
+++ b/tests/test_fp.py
@@ -1,3 +1,6 @@
+import pytest
+import torch.cuda
+
 from tests import MISTRAL_TEST_DIR, run_tests, run_train_process
 
 
@@ -8,7 +11,6 @@ CACHE_DIR = f"{MISTRAL_TEST_DIR}/artifacts"
 RUNS_DIR = f"{MISTRAL_TEST_DIR}/runs"
 RUN_ID = "upcasting_test"
 RUN_ID_DIR = f"{RUNS_DIR}/{RUN_ID}"
-LAST_CHECKPOINT = "checkpoint-18"
 
 # run training processes for tests
 TRAIN_ARGS = {
@@ -24,6 +26,7 @@ TRAIN_ARGS = {
 }
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="need cuda for fp16")
 def test_upcasting() -> None:
     """
     Run training with upcasting

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -23,11 +23,20 @@ TRAIN_ARGS_SEED_7 = {
     "run_final_eval": "false",
 }
 
-trainer_seed_7 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_7, runs_dir=RUNS_DIR, run_id="trainer_seed_7")
-
 TRAIN_ARGS_SEED_10 = dict(TRAIN_ARGS_SEED_7)
 TRAIN_ARGS_SEED_10["seed"] = "10"
-trainer_seed_10 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_10, runs_dir=RUNS_DIR, run_id="trainer_seed_10")
+
+trainer_seed_7 = None
+trainer_seed_10 = None
+trainer_seed_7_copy = None
+
+
+def setup_module() -> None:
+    global trainer_seed_7, trainer_seed_10, trainer_seed_7_copy
+    trainer_seed_7 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_7, runs_dir=RUNS_DIR, run_id="trainer_seed_7")
+    trainer_seed_10 = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_10, runs_dir=RUNS_DIR, run_id="trainer_seed_10")
+    trainer_seed_7_copy = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_7, runs_dir=RUNS_DIR,
+                                            run_id="trainer_seed_7_copy")
 
 
 def is_randomized(key):
@@ -57,8 +66,6 @@ def test_data_order() -> None:
     seed_10_dataloader = trainer_seed_10.get_train_dataloader()
     seed_7_indices, seed_10_indices = list(iter(seed_7_dataloader.sampler)), list(iter(seed_10_dataloader.sampler))
 
-    trainer_seed_7_copy = run_train_process(cl_args_dict=TRAIN_ARGS_SEED_7, runs_dir=RUNS_DIR,
-                                            run_id="trainer_seed_7_copy")
     seed_7_copy_dataloader = trainer_seed_7_copy.get_train_dataloader()
     seed_7_copy_indices = list(iter(seed_7_copy_dataloader.sampler))
 

--- a/tests/test_valid_configs.py
+++ b/tests/test_valid_configs.py
@@ -1,0 +1,42 @@
+import sys
+from unittest.mock import patch
+
+from quinine.common.argparse import QuinineArgumentParser
+
+import tests
+import pathlib
+
+from conf.train_schema import get_schema
+
+expected_manual_args = [
+    "--artifacts.cache_dir", "artifacts/cache",
+    "--artifacts.run_dir", "artifacts/runs",
+]
+
+def validate_config(config_file):
+    try:
+        cl_args = ["--config", str(config_file)] + expected_manual_args
+        with patch.object(sys, "argv", ["foo.py"] + cl_args):
+            QuinineArgumentParser(schema=get_schema()).parse_quinfig()
+    except Exception as e:
+        raise Exception(f"{config_file} is not valid: {e}") from e
+
+
+def test_all_test_configs_are_valid():
+    # test all the yaml files in the main mistral conf directory, and in the mistral tests/conf directory
+    test_root = pathlib.Path(tests.__file__).parent.absolute()
+
+    for path in pathlib.Path(test_root).glob('conf/*.yaml'):
+        validate_config(path)
+
+def test_all_real_configs_are_valid():
+    # test all the yaml files in the main mistral conf directory, and in the mistral tests/conf directory
+    mistral_root = pathlib.Path(tests.__file__).parent.parent.absolute()
+
+    for path in pathlib.Path(mistral_root).glob('conf/*.yaml'):
+        validate_config(path)
+
+
+
+if __name__ == "__main__":
+    tests.run_tests()


### PR DESCRIPTION
(joint work with @j38)

Sorry this ended up being a few changes that could be broken up, but it's not too huge really.

1. add a new setup script/directory with conda and pip requirements broken out
2. make CI setup and tear down a conda env and the pip requirements. CI deletes it at end of run
3. CI uses pytest to discover tests
4. refactor tests to make pytest discovery a little less painful (mostly deferring running training processes until it's time to test)
5. add a test to ensure that top level config yamls are valid