### PR TITLE
Add pyarrow>=7.0.0 to requirements

### DIFF
--- a/setup/pip-requirements.txt
+++ b/setup/pip-requirements.txt
@@ -7,3 +7,4 @@ quinine==0.3.0
 transformers==4.18.0
 wandb==0.12.17
 zstandard>=0.17.0
+pyarrow>=7.0.0


### PR DESCRIPTION
Add pyarrow>=7.0.0 to requirements, which is required to use `pyarrow.parquet.ParquetWriter.write_batch`.

Fixes #183